### PR TITLE
chore(poetry): change to `acad_gpt` so poetry can install new venv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     "Navdeeppal Singh <npsingh0181@gmail.com>"
 ]
 readme = "README.md"
-packages = [{include = "chatgpt_memory"}]
+packages = [{include = "acad_gpt"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
makes installing via poetry not work since the package has already been renamed. single line change